### PR TITLE
Link fixup for unknown channel id exclude

### DIFF
--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -29,6 +29,6 @@ $logwarn ${options} -m '\[.*:(debug|info|warn|error)\]' -p ${file} \
     '!Error sending AMQP event: Channel is not open' \
     `# https://progress.opensuse.org/issues/18048` \
     '!warn\] AMQP connection closed' \
-    `# add bugzilla here` \
+    `# https://progress.opensuse.org/issues/18052` \
     '!warn\] Error on AMQP channel received: Failed closing channel: Unknown channel id received: 1' \
     '\[.*:(warn|error)\]' '!\[.*:(debug|info)\]' $@


### PR DESCRIPTION
I've missed to add the URL inside the source so here is a fixup of this.