### PR TITLE
Fix missing linebreak

### DIFF
--- a/logwarn_openqa
+++ b/logwarn_openqa
@@ -44,5 +44,5 @@ $logwarn ${options} -m '\[.*:(debug|info|warn|error)\]' -p ${file} \
     `# https://progress.opensuse.org/issues/19732` \
     '!scheduler:warn\] .* wants to grab a new job - killing the old one.*' \
     `# https://progress.opensuse.org/issues/19756` \
-    '!websockets:error\] Unknown property received from worker .*'
+    '!websockets:error\] Unknown property received from worker .*' \
     '\[.*:(warn|error)\]' '!\[.*:(debug|info)\]' $@


### PR DESCRIPTION
Fixes:
"/opt/openqa_monitoring/logwarn_openqa: line 48: \[.*:(warn|error)\]: command not found"