### PR TITLE
Introducing the "pretty_logwarn" wrapper

### DIFF
--- a/pretty_logwarn
+++ b/pretty_logwarn
@@ -6,7 +6,7 @@ set -e
 HOST=$(hostname --long)
 SUBJECT="OpenQA logreport for $HOST"
 SENDER="openqa-monitor@$HOST"
-SENDTO="${SENDTO:-"nsinger@suse.de"}"
+REPORTTO="${REPORTTO:-"nsinger@suse.de"}"
 
 # automatically update the script while preserving maybe added hotfixes
 cd /opt/openqa_monitoring
@@ -20,5 +20,5 @@ WARNINGS=$(./logwarn_openqa "$1")
 set -e
 
 if [ ! -z "$WARNINGS" ]; then
-    echo "$WARNINGS" | mail -r "$SENDER" -s "$SUBJECT" "$SENDTO"
+    echo "$WARNINGS" | mail -r "$SENDER" -s "$SUBJECT" "$REPORTTO"
 fi

--- a/pretty_logwarn
+++ b/pretty_logwarn
@@ -11,7 +11,9 @@ SENDTO="${SENDTO:-"nsinger@suse.de"}"
 
 #automatically update the script while preserving maybe added hotfixes
 cd /opt/openqa_monitoring
-git pull --quiet --rebase origin master
+# git pull --quiet --rebase origin master # This sometimes fails with "cannot rebase onto multiple branches".
+git fetch --quiet --all --prune
+git rebase --quiet origin/master
 
 #script exits with 1 if errors a found so don't exit here on exitcode != 0
 set +e

--- a/pretty_logwarn
+++ b/pretty_logwarn
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+
+#exit if failure occours inside the script
+set -e
+
+HOST=$(hostname --long)
+SUBJECT="OpenQA logreport for $HOST"
+SENDER="openqa-monitor@$HOST"
+SENDTO="${SENDTO:-"nsinger@suse.de"}"
+
+#automatically update the script while preserving maybe added hotfixes
+cd /opt/openqa_monitoring
+git pull --quiet --rebase origin master
+
+#script exits with 1 if errors a found so don't exit here on exitcode != 0
+set +e
+WARNINGS=$(./logwarn_openqa "$1")
+set -e
+
+if [ ! -z "$WARNINGS" ]; then
+    echo "$WARNINGS" | mail -r "$SENDER" -s "$SUBJECT" "$SENDTO"
+fi

--- a/pretty_logwarn
+++ b/pretty_logwarn
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-
-#exit if failure occours inside the script
+# exit if failure occours inside the script
 set -e
 
 HOST=$(hostname --long)
@@ -9,13 +8,13 @@ SUBJECT="OpenQA logreport for $HOST"
 SENDER="openqa-monitor@$HOST"
 SENDTO="${SENDTO:-"nsinger@suse.de"}"
 
-#automatically update the script while preserving maybe added hotfixes
+# automatically update the script while preserving maybe added hotfixes
 cd /opt/openqa_monitoring
 # git pull --quiet --rebase origin master # This sometimes fails with "cannot rebase onto multiple branches".
 git fetch --quiet --all --prune
 git rebase --quiet origin/master
 
-#script exits with 1 if errors a found so don't exit here on exitcode != 0
+# script exits with 1 if new errors are found so don't exit here on exitcode != 0
 set +e
 WARNINGS=$(./logwarn_openqa "$1")
 set -e


### PR DESCRIPTION
This PR introduces a "pretty_logwarn" script which mostly takes care of the mail formatting (subject and sender) and the auto update with the help of git.
By using a separate script to send out mails, we can make use of the cron mail feature to handle unexpected script failures separately to expected report mails.